### PR TITLE
Added handler for DEFAULT keyword in Property.update for ALTER PROPER…

### DIFF
--- a/lib/db/class/property.js
+++ b/lib/db/class/property.js
@@ -223,6 +223,9 @@ Property.update = function (property, reload) {
   if (property.notNull !== undefined) {
     promises.push(this.db.exec(prefix + 'NOTNULL ' + (property.notNull ? 'true' : 'false')));
   }
+  if (property.default !== undefined) {
+    promises.push(this.db.exec(prefix + 'DEFAULT ' + property.default));
+  }
 
   if (property.custom) {
     keys = Object.keys(property.custom);


### PR DESCRIPTION
…TY statements

See [#40](https://github.com/orientechnologies/orientjs/issues/40)

Tried integrating it to the existing property.update unit test, but apparently the default attribute of the property is not sent back although it is successfully set in the DB. Not sure why that is, is it OrientDB or orientjs behaviour ? Would appreciate some light on the matter. :)