### PR TITLE
Add support to create and update raw binary records (ORecordBytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Install via npm.
 npm install orientjs
 ```
 
+To install OrientJS globally use the `-g` option:
+
+```sh
+npm install orientjs -g
+```
+
 # Running Tests
 
 To run the test suite, first invoke the following command within the repo, installing the development dependencies:

--- a/README.md
+++ b/README.md
@@ -455,6 +455,19 @@ MyClass.list()
 });
 ```
 
+### Creating raw binary records
+
+```js
+var binary_data = new Buffer(...);
+// ...
+binary_data['@type'] = 'b'; // state that the record is a raw binary record
+binary_data['@class'] = 'Binary'; // here '@class' does NOT mean a class, but a cluster
+db.record.create(binary_data)
+.then(function (record) {
+  console.log('Created record. RID:', binary_data['@rid']);
+});
+```
+
 ### Create a new index for a class property
 
 ```js

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ MyClass.list()
 var binary_data = new Buffer(...);
 // ...
 binary_data['@type'] = 'b'; // state that the record is a raw binary record
-binary_data['@class'] = 'Binary'; // here '@class' does NOT mean a class, but a cluster
+binary_data['@class'] = 'MyBinary'; // here '@class' does NOT mean a class, but a cluster
 db.record.create(binary_data)
 .then(function (record) {
   console.log('Created record. RID:', binary_data['@rid']);

--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -54,6 +54,7 @@ exports.create = function (record, options) {
     return this.send('record-create', {
       segment: options.segment != null ? +options.segment : -1,
       cluster: rid.cluster,
+      type: record['@type'],
       record: record
     });
   })

--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -249,25 +249,52 @@ exports.update = function (record, options) {
     return Promise.reject(new errors.Operation('Cannot update record -  record ID is not specified or invalid.'));
   }
 
-  record['@type']  = 'd';
+  if (!record['@type'])
+  {
+    record['@type']  = 'd';
+  }
 
   data = {
     cluster: rid.cluster,
     position: rid.position,
+    type: record['@type'],
     mode: options.mode || 0
   };
 
   if (options.preserve && rid) {
     promise = this.record.get(rid)
     .then(function (found) {
-      var keys = Object.keys(record),
-          total = keys.length,
-          key, i;
-      for (i = 0; i < total; i++) {
-        key = keys[i];
-        found[key] = record[key];
+      var keys, total, key, i;
+      if (found['@type'] === 'b') {
+        keys = Object.keys(found);
+        total = keys.length;
+        var foundClone = new Buffer(record);
+        for (i = 0; i < total; i++) {
+          key = keys[i];
+          if (key.charAt(0) === '@') {
+            foundClone[key] = record[key];
+          }
+        }
+
+        keys = Object.keys(record);
+        total = keys.length;
+        for (i = 0; i < total; i++) {
+          key = keys[i];
+          if (key.charAt(0) === '@') {
+            foundClone[key] = record[key];
+          }
+        }
+        return foundClone;
       }
-      return found;
+      else {
+        keys = Object.keys(record);
+        total = keys.length;
+        for (i = 0; i < total; i++) {
+          key = keys[i];
+          found[key] = record[key];
+        }
+        return found;
+      }
     });
   }
   else {

--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -272,7 +272,7 @@ exports.update = function (record, options) {
         for (i = 0; i < total; i++) {
           key = keys[i];
           if (key.charAt(0) === '@') {
-            foundClone[key] = record[key];
+            foundClone[key] = found[key];
           }
         }
 

--- a/lib/transport/binary/protocol28/operations/record-create.js
+++ b/lib/transport/binary/protocol28/operations/record-create.js
@@ -9,7 +9,7 @@ module.exports = Operation.extend({
   id: 'REQUEST_RECORD_CREATE',
   opCode: 31,
   writer: function () {
-    var rid, cluster;
+    var rid, cluster, content;
     if (this.data.record['@rid']) {
       rid = RID.parse(this.data.record['@rid']);
       cluster = this.data.cluster || rid.cluster;
@@ -17,10 +17,16 @@ module.exports = Operation.extend({
     else {
       cluster = this.data.cluster;
     }
+    if (this.data.type === 'b') {
+      content = this.data.record;
+    }
+    else {
+      content = serializer.encodeRecordData(this.data.record);
+    }
     this
     .writeHeader(this.opCode, this.data.sessionId, this.data.token)
     .writeShort(cluster)
-    .writeBytes(serializer.encodeRecordData(this.data.record))
+    .writeBytes(content)
     .writeByte(constants.RECORD_TYPES[this.data.type || 'd'])
     .writeByte(this.data.mode || 0);
   },

--- a/lib/transport/binary/protocol28/operations/record-update.js
+++ b/lib/transport/binary/protocol28/operations/record-update.js
@@ -9,7 +9,7 @@ module.exports = Operation.extend({
   id: 'REQUEST_RECORD_UPDATE',
   opCode: 32,
   writer: function () {
-    var rid, cluster, position, version;
+    var rid, cluster, position, version, content;
     if (this.data.record['@rid']) {
       rid = RID.parse(this.data.record['@rid']);
       cluster = this.data.cluster || rid.cluster;
@@ -18,6 +18,12 @@ module.exports = Operation.extend({
     else {
       cluster = this.data.cluster;
       position = this.data.position;
+    }
+    if (this.data.type === 'b') {
+      content = this.data.record;
+    }
+    else {
+      content = serializer.encodeRecordData(this.data.record);
     }
     if (this.data.version != null) {
       version = this.data.version;
@@ -33,7 +39,7 @@ module.exports = Operation.extend({
     .writeShort(cluster)
     .writeLong(position)
     .writeBoolean(true)
-    .writeBytes(serializer.encodeRecordData(this.data.record))
+    .writeBytes(content)
     .writeInt(version)
     .writeByte(constants.RECORD_TYPES[this.data.type || 'd'])
     .writeByte(this.data.mode || 0);

--- a/lib/transport/binary/protocol28/operations/tx-commit.js
+++ b/lib/transport/binary/protocol28/operations/tx-commit.js
@@ -26,7 +26,12 @@ module.exports = Operation.extend({
       this.writeShort(item['@rid'].cluster);
       this.writeLong(item['@rid'].position);
       this.writeByte(constants.RECORD_TYPES[item['@type'] || 'd'] || 100); // document by default
-      this.writeBytes(serializer.encodeRecordData(item));
+      if (item['@type'] === 'b') {
+        this.writeBytes(item);
+      }
+      else {
+        this.writeBytes(serializer.encodeRecordData(item));
+      }
     }
 
     // updates
@@ -40,7 +45,12 @@ module.exports = Operation.extend({
       this.writeLong(item['@rid'].position);
       this.writeByte(constants.RECORD_TYPES[item['@type'] || 'd'] || 100); // document by default
       this.writeInt(item['@version'] || 0);
-      this.writeBytes(serializer.encodeRecordData(item));
+      if (item['@type'] === 'b') {
+        this.writeBytes(item);
+      }
+      else {
+        this.writeBytes(serializer.encodeRecordData(item));
+      }
       this.writeBoolean(true);
     }
 

--- a/test/bugs/158-orderby-skip.js
+++ b/test/bugs/158-orderby-skip.js
@@ -1,0 +1,53 @@
+var Promise = require('bluebird');
+
+//@dmarcelino test case
+
+describe("Bug #158: order by with skip returning 0 results", function () {
+    before(function () {
+        return CREATE_TEST_DB(this, 'testdb_bug_158')
+            .bind(this)
+            .then(function () {
+                return Promise.map([
+                    'CREATE CLASS customerTable EXTENDS V',
+                    'CREATE PROPERTY customerTable.name STRING',
+
+                    'INSERT INTO customerTable SET name = "hasmany find pop"',
+                    'INSERT INTO customerTable SET name = "hasmany find pop"',
+                ], this.db.query.bind(this.db));
+            });
+    });
+    after(function () {
+        return DELETE_TEST_DB('testdb_bug_158');
+    });
+    // Control tests
+    it('should return two records when using ORDER BY', function () {
+        return this.db.query('SELECT name, @rid FROM customerTable WHERE name.toLowerCase() = "hasmany find pop" ORDER BY @rid ASC')
+            .then(function (results) {
+                results.length.should.equal(2);
+                results[0].name.should.equal('hasmany find pop');
+            });
+    });
+    it('should return one record when using SKIP', function () {
+        return this.db.query('SELECT name, @rid FROM customerTable WHERE name.toLowerCase() = "hasmany find pop" SKIP 1')
+            .then(function (results) {
+                results.length.should.equal(1);
+                results[0].name.should.equal('hasmany find pop');
+            });
+    });
+    // The relevant test case
+    it('should return one record when using ORDER BY and SKIP', function () {
+        return this.db.query('SELECT name, @rid FROM customerTable WHERE name.toLowerCase() = "hasmany find pop" ORDER BY @rid ASC SKIP 1')
+            .then(function (results) {
+                results.length.should.equal(1);
+                results[0].name.should.equal('hasmany find pop');
+            });
+    });
+    // Workaround as suggested by phpnode
+    it('should return one record when using ORDER BY and SKIP and LIMIT', function () {
+        return this.db.query('SELECT name, @rid FROM customerTable WHERE name.toLowerCase() = "hasmany find pop" ORDER BY @rid ASC SKIP 1 LIMIT 2147483646')
+            .then(function (results) {
+                results.length.should.equal(1);
+                results[0].name.should.equal('hasmany find pop');
+            });
+    });
+});

--- a/test/db/record-test.js
+++ b/test/db/record-test.js
@@ -1,4 +1,4 @@
-var createdRID, demoRID1, demoRID2;
+var createdRID, createdBinaryRID, demoRID1, demoRID2;
 
 describe("Database API - Record", function () {
   before(function () {
@@ -56,6 +56,20 @@ describe("Database API - Record", function () {
       });
     });
 
+    it('should create a raw binary record', function () {
+      var binary_message = new Buffer(100);
+      for (var i = 0; i < 100; i++)
+      {
+        binary_message[i] = i + 1;
+      }
+      binary_message['@type'] = 'b';
+      binary_message['@class'] = 'V';
+      return this.db.record.create(binary_message)
+      .then(function (record) {
+        createdBinaryRID = record['@rid'];
+      });
+    });
+
     it('should create a record with a dynamic linked field', function () {
       return this.db.record.create({
         '@class': 'OUser',
@@ -106,6 +120,20 @@ describe("Database API - Record", function () {
       return this.db.record.update({'@rid': createdRID, name: 'testuserrenamed'}, {preserve: true})
       .then(function (record) {
         record.name.should.equal('testuserrenamed');
+      });
+    });
+
+    it('should update a raw binary record', function () {
+      var binary_message = new Buffer(100);
+      for (var i = 0; i < 100; i++)
+      {
+        binary_message[i] = 100 - i;
+      }
+      binary_message['@type'] = 'b';
+      binary_message['@rid'] = createdBinaryRID;
+      return this.db.record.update(binary_message, {preserve: true})
+      .then(function (record) {
+        record.toString().should.equal(binary_message.toString());
       });
     });
 
@@ -163,6 +191,9 @@ describe("Database API - Record", function () {
   describe('Db::record.delete()', function () {
     it('should delete a record', function () {
       return this.db.record.delete(createdRID);
+    });
+    it('should delete a raw binary record', function () {
+      return this.db.record.delete(createdBinaryRID);
     });
   });
 


### PR DESCRIPTION
This patch adds support to create and update raw binary records (ORecordBytes) as stated at https://orientdb.com/docs/last/Binary-Data.html#store-it-with-orecordbytes. It supports raw binary records for both direct creating / updating of records and using transactions to create / update records.

**Note:** I have added this function only for binary protocol 28.

It resolves #52 and #7.