### PR TITLE
added support for metadata (index create)

### DIFF
--- a/lib/db/index/index.js
+++ b/lib/db/index/index.js
@@ -181,6 +181,10 @@ Index.create = function (config) {
   if (config.keyType) {
     query += ' ' + config.keyType;
   }
+  
+  if (config.metadata) {
+    query += ' METADATA ' + JSON.stringify(config.metadata);
+  }
 
   return this.query(query)
   .bind(this)


### PR DESCRIPTION
Hi
I have added support for CREATE INDEX with metadata.

Example
```js
db.index.create({
  name: 'MyClass.myProp',
  type: 'unique',
  metadata: {
    ignoreNullValues: false
  }
});
```

```sql
CREATE INDEX <name> [ON <class-name> (prop-names)] <type> [<key-type>] 
  METADATA [{<json-metadata>}]
```