### PR TITLE
fix #69

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -135,7 +135,11 @@ Statement.prototype.add = function (property/*, ...values*/) {
       values = new Array(totalArguments - 1),
       a;
   for (a = 1; a < totalArguments; a++) {
-    values[a - 1] = arguments[a];
+    if (!(arguments[a] instanceof RID) && RID.isValid(arguments[a])) {
+      values[a - 1] = RID(arguments[a]);
+    } else {
+      values[a - 1] = arguments[a];
+    }
   }
   this._state.add = this._state.add || [];
   this._state.add.push([property, values]);
@@ -155,7 +159,11 @@ Statement.prototype.remove = function (property/*, ...values*/) {
       values = new Array(totalArguments - 1),
       a;
   for (a = 1; a < totalArguments; a++) {
-    values[a - 1] = arguments[a];
+    if (!(arguments[a] instanceof RID) && RID.isValid(arguments[a])) {
+      values[a - 1] = RID(arguments[a]);
+    } else {
+      values[a - 1] = arguments[a];
+    }
   }
   this._state.remove = this._state.remove || [];
   this._state.remove.push([property, values]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -214,6 +214,9 @@ exports.encode = function encode (value) {
     return value;
   }
   else if (typeof value === 'string') {
+    if (value.charAt(0) === '$') {
+      return exports.escape(value);
+    }
     return '"' + exports.escape(value) + '"';
   }
   else if (value instanceof Date) {


### PR DESCRIPTION
Remove quotes from strings starting with $
Convert RID's from string to objects when doing an add/remove

This allow to do a "add" operation into transactions, with parameters like $previous.@rid
This allow to do a "add" operations with a RID without converting it into a real RID object