### PR TITLE
Update utils.js - fixed encoding of RID strings

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -214,7 +214,7 @@ exports.encode = function encode (value) {
     return value;
   }
   else if (typeof value === 'string') {
-    if (value.match(/^\#\d+\:\d+$/)) {
+    if (value.match(/^#\d+:\d+$/)) {
       return value;
     }
     return '"' + exports.escape(value) + '"';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -214,6 +214,9 @@ exports.encode = function encode (value) {
     return value;
   }
   else if (typeof value === 'string') {
+    if (value.match(/^\#\d+\:\d+$/)) {
+      return value;
+    }
     return '"' + exports.escape(value) + '"';
   }
   else if (value instanceof Date) {


### PR DESCRIPTION
Do not put strings containing a RID into quotes when building a query.

With this change it is possible to use a string containing a RID directly, without converting to an RID object.

Related to issues #59 and #69.

