### PR TITLE
update load request for reading binary payloads

### DIFF
--- a/lib/transport/binary/protocol28/operations/record-load.js
+++ b/lib/transport/binary/protocol28/operations/record-load.js
@@ -73,11 +73,11 @@ module.exports = Operation.extend({
           this
           .readChar('type')
           .readInt('version')
-          .readString('content', function (data, fieldName) {
+          .readBytes('content', function (data, fieldName) {
             data.cluster = this.data.cluster;
             data.position = this.data.position;
             if (data.type === 'd') {
-              data.content = deserializer.deserialize(data.content, this.data.transformerFunctions);
+              data.content = deserializer.deserialize(data.content.toString(), this.data.transformerFunctions);
             }
             this.stack.pop();
             this.readPayload(records, ender);

--- a/lib/transport/binary/protocol28/operations/record-load.js
+++ b/lib/transport/binary/protocol28/operations/record-load.js
@@ -101,9 +101,9 @@ module.exports = Operation.extend({
                 .readShort('cluster')
                 .readLong('position')
                 .readInt('version')
-                .readString('content', function (data, fieldName) {
+                .readBytes('content', function (data, fieldName) {
                   if (data.type === 'd') {
-                    data.content = deserializer.deserialize(data.content, this.data.transformerFunctions);
+                    data.content = deserializer.deserialize(data.content.toString(), this.data.transformerFunctions);
                   }
                   this.stack.pop();
                   this.readPayload(records, ender);


### PR DESCRIPTION
Based on Binary protocol documentation  REQUEST_RECORD_LOAD must be in this format :
http://orientdb.com/docs/2.1/Network-Binary-Protocol.html#request_record_load

  Request: (cluster-id:short)(cluster-position:long)(fetch-plan:string)(ignore-cache:boolean)(load-tombstones:boolean)
  Response: [(payload-status:byte)[(record-type:byte)(record-version:int)(record-content:bytes)]*]+

in some case like reading binary record may returns wrong output . 

now i correct it.