### PR TITLE
Allow use of classic tls

### DIFF
--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var net = require('net'),
+	tls = require('tls'),
     util = require('util'),
     utils = require('../../utils'),
     errors = require('../../errors'),
@@ -13,6 +14,8 @@ var net = require('net'),
 function Connection (config) {
   EventEmitter.call(this);
   config = config || {};
+  this.ssl = config.ssl || false;
+  this.ca = config.ssl-ca || '';
   this.host = config.host || 'localhost';
   this.port = +config.port || 2424;
   this.socket = null;
@@ -126,7 +129,14 @@ Connection.prototype.cancel = function (err) {
  * @return {Socket} The socket.
  */
 Connection.prototype.createSocket = function () {
-  var socket = net.createConnection(this.port, this.host);
+  var socket = null;
+  if (this.ssl) {
+    socket = tls.createConnection(this.port, this.host, {
+      ca: this.ca
+    });
+  }
+  else
+    socket = net.createConnection(this.port, this.host);
   socket.setNoDelay(true);
   socket.setMaxListeners(100);
   return socket;

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -132,12 +132,14 @@ Connection.prototype.createSocket = function () {
   var socket = null;
   if (this.ssl) {
     var opts = {};
-    if (this.sslca)
+    if (this.sslca) {
       opts.ca = this.sslca;
+    }
     socket = tls.connect(this.port, this.host, opts);
   }
-  else
+  else {
     socket = net.createConnection(this.port, this.host);
+  }
   socket.setNoDelay(true);
   socket.setMaxListeners(100);
   return socket;

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -15,7 +15,7 @@ function Connection (config) {
   EventEmitter.call(this);
   config = config || {};
   this.ssl = config.ssl || false;
-  this.ca = config.ssl-ca || '';
+  this.sslca = config.sslca || '';
   this.host = config.host || 'localhost';
   this.port = +config.port || 2424;
   this.socket = null;
@@ -131,9 +131,10 @@ Connection.prototype.cancel = function (err) {
 Connection.prototype.createSocket = function () {
   var socket = null;
   if (this.ssl) {
-    socket = tls.createConnection(this.port, this.host, {
-      ca: this.ca
-    });
+    var opts = {};
+    if (this.sslca)
+      opts.ca = this.sslca;
+    socket = tls.connect(this.port, this.host, opts);
   }
   else
     socket = net.createConnection(this.port, this.host);

--- a/lib/transport/binary/index.js
+++ b/lib/transport/binary/index.js
@@ -21,6 +21,7 @@ function BinaryTransport (config) {
   this.setMaxListeners(Infinity);
   this.configure(config || {});
   this.closing = false;
+  console.log(config);
 }
 
 util.inherits(BinaryTransport, EventEmitter);
@@ -44,6 +45,8 @@ BinaryTransport.prototype.configure = function (config) {
 
   this.host = config.host || config.hostname || 'localhost';
   this.port = config.port || 2424;
+  this.ssl = config.ssl || false;
+  this.sslca = config.sslca || '';
   this.username = config.username || 'root';
   this.password = config.password || '';
 
@@ -86,6 +89,8 @@ BinaryTransport.prototype.configureConnection = function () {
   this.connection = new Connection({
     host: this.host,
     port: this.port,
+    ssl: this.ssl,
+    sslca: this.sslca,
     enableRIDBags: this.enableRIDBags,
     logger: this.logger,
     useToken: this.useToken

--- a/lib/transport/binary/index.js
+++ b/lib/transport/binary/index.js
@@ -21,7 +21,6 @@ function BinaryTransport (config) {
   this.setMaxListeners(Infinity);
   this.configure(config || {});
   this.closing = false;
-  console.log(config);
 }
 
 util.inherits(BinaryTransport, EventEmitter);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orientjs",
+  "name": "orientjsamerle",
   "description": "Official node.js driver for OrientDB. Fast, lightweight, uses the binary protocol.",
   "keywords": [
     "orientdb",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orientjsamerle",
+  "name": "orientjs",
   "description": "Official node.js driver for OrientDB. Fast, lightweight, uses the binary protocol.",
   "keywords": [
     "orientdb",


### PR DESCRIPTION
Allow creation server with {
 ssl: true,
 ca: <content of ca-file>
}
options, to use classic tls over load balancer with / instead java keystore method