### PR TITLE
recreated deserializeDocument (fixes random bugs)

### DIFF
--- a/lib/transport/rest/protocol/deserializer.js
+++ b/lib/transport/rest/protocol/deserializer.js
@@ -13,14 +13,16 @@ var RecordID = require('../../../recordid'),
  */
 function deserializeDocument (serialized) {
   try {
+    var fieldTypes = prepareFieldTypes(serialized['@fieldTypes']) || {};
     return JSON.parse(serialized, function (key, value) {
       if (key === '@rid') {
         return new RecordID(value);
-      }
-      else if (key === '@fieldTypes') {
-        applyFieldTypes(this);
-      }
-      else {
+      } else {
+        var fieldType = fieldTypes[key];
+      	if (fieldType) {
+      	  return applyFieldType(fieldType, value);
+      	}
+
         return value;
       }
     });
@@ -30,17 +32,15 @@ function deserializeDocument (serialized) {
   }
 }
 
-function applyFieldTypes (subject) {
-  var types = subject['@fieldTypes'].split(','),
-      total = types.length,
-      i, parts, fieldName, type;
-  for (i = 0; i < total; i++) {
-    parts = types[i].split('=');
-    fieldName = parts[0];
-    type = parts[1];
-    subject[fieldName] = applyFieldType(type, subject[fieldName]);
+function prepareFieldTypes(fieldTypes) {
+  if (!fieldTypes) {
+    return;
   }
-  return subject;
+  return fieldTypes.split(',').reduce(function (memo, item) {
+    var parts = item.split('=');
+    memo[parts[0]] = parts[1];
+    return memo;
+  }, {});
 }
 
 function applyFieldType (type, value) {


### PR DESCRIPTION
The old method was applying the field types as part of the keys.
The old way was problematic, mainly because the order of the keys isn't correct. If the ``@fieldTypes`` key would hit the loop first, it would use empty values and not set anything. If it would come last, it would come after the values has already been parsed (in which case Long.parseString throws errors, since the function assumes the input has .charAt() method, which the parsed number passed to it, doesn't).