### PR TITLE
Parameterized queries doesn't work with REST

### DIFF
--- a/lib/transport/rest/protocol/operations/command.js
+++ b/lib/transport/rest/protocol/operations/command.js
@@ -7,7 +7,8 @@ module.exports = Operation.extend({
   id: 'REQUEST_COMMAND',
   opCode: 41,
   requestConfig: function () {
-    var prepared = utils.prepare(this.data.query, this.data.params),
+    var params = this.data.params;
+    var prepared = utils.prepare(this.data.query, params && params.params),
         url = '/command/' + this.data.database + '/sql/' + prepared;
     if (this.data.limit) {
       url += '/' + this.data.limit;

--- a/test/transport/rest/rest-transport-test.js
+++ b/test/transport/rest/rest-transport-test.js
@@ -109,6 +109,24 @@ describe("Rest Transport", function () {
           fromRest.results[0].content.length.should.equal(fromBinary.results[0].content.length);
         });
       });
+      it('should execute a parameterized query', function () {
+        var config = {
+          database: 'testdb_rest',
+          class: 'com.orientechnologies.orient.core.sql.query.OSQLSynchQuery',
+          query: 'SELECT * FROM OUser WHERE name = :name',
+          mode: 's',
+          limit: -1,
+          params: { params: { name: "reader" } }
+        };
+        return Promise.all([REST_SERVER.send('command', config), this.db.send('command', config)])
+        .spread(function (fromRest, fromBinary) {
+          fromRest.results.length.should.equal(fromBinary.results.length);
+          fromRest.results[0].content.length.should.equal(fromBinary.results[0].content.length);
+        }).catch(function (err) {
+          console.log("Erorr: ", err.stack || err);
+          throw err;
+        });
+      });
     });
 
 


### PR DESCRIPTION
Title says it all.

You can see the same operation is done in the binary protocol:
https://github.com/orientechnologies/orientjs/blob/master/lib/transport/binary/protocol28/operations/command.js#L29

It's just missing from the REST protocol.
Also added a test case to demonstrate it.
