### PR TITLE
Add in operator for where clause (fixes #145)

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -221,6 +221,7 @@ Statement.prototype.lt = whereClause('and', '<');
 Statement.prototype.lte = whereClause('and', '<=');
 Statement.prototype.ne = whereClause('and', '<>');
 Statement.prototype.is = whereClause('and', 'IS');
+Statement.prototype.in = whereClause('and', 'IN');
 Statement.prototype.instanceOf = whereClause('and', 'INSTANCEOF');
 
 /**


### PR DESCRIPTION
Just another where operator to handle the following statement:

```javascript
db.select().from('OUser').in({ '@rid': userIds }).all()
```