### PR TITLE
Friendly "endQuery" for logging

### DIFF
--- a/lib/db/db.js
+++ b/lib/db/db.js
@@ -250,7 +250,7 @@ Db.prototype.exec = function (query, options) {
     this.emit("beginQuery", data);
   }
 
-  var promise = this.send('command', data);
+  var promise = this.send('command', utils.clone(data));
 
   if (this.listeners('endQuery').length > 0) {
     var err, e, s = Date.now();
@@ -265,7 +265,8 @@ Db.prototype.exec = function (query, options) {
           err: err,
           result: res,
           perf: {
-            query: e - s
+            query: data,
+            ms: e - s
           }
         });
       });


### PR DESCRIPTION
I would like to use "endQuery" event for logging, because it has query time. Example:
```
db.on('endQuery', function(obj) {
    console.log('Query:', obj.perf.ms, obj.perf.query);
});
```