### PR TITLE
Added TLS for port range 2434-2440

### DIFF
--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -130,20 +130,20 @@ Connection.prototype.cancel = function (err) {
  * @return {Socket} The socket.
  */
 Connection.prototype.createSocket = function () {
+  var socket;
   if(this.port >= 2434 && this.port <= 2440)
   {
-    var socket = tls.connect(this.port, this.host);
+    socket = tls.connect(this.port, this.host);
     socket.setNoDelay(true);
     socket.setMaxListeners(100);
-    return socket;
   }
   else
   {
-    var socket = net.createConnection(this.port, this.host);
+    socket = net.createConnection(this.port, this.host);
     socket.setNoDelay(true);
     socket.setMaxListeners(100);
-    return socket;
   }
+  return socket;
 };
 
 /**

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -132,14 +132,14 @@ Connection.prototype.cancel = function (err) {
 Connection.prototype.createSocket = function () {
   if(this.port >= 2434 && this.port <= 2440)
   {
-	  var socket = tls.connect(this.port, this.host);
-	  socket.setNoDelay(true);
-	  socket.setMaxListeners(100);
-	  return socket;
+    var socket = tls.connect(this.port, this.host);
+    socket.setNoDelay(true);
+    socket.setMaxListeners(100);
+    return socket;
   }
   else
   {
-    socket = net.createConnection(this.port, this.host);
+    var socket = net.createConnection(this.port, this.host);
     socket.setNoDelay(true);
     socket.setMaxListeners(100);
     return socket;

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -7,8 +7,8 @@ var net = require('net'),
   OperationStatus = require('./operation-status'),
   EventEmitter = require('events').EventEmitter,
   Promise = require('bluebird'),
-  Operation;
-const tls = require('tls');
+  Operation,
+  tls = require('tls');
 
 
 function Connection(config) {

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -8,6 +8,7 @@ var net = require('net'),
   EventEmitter = require('events').EventEmitter,
   Promise = require('bluebird'),
   Operation;
+const tls = require('tls');
 
 
 function Connection(config) {
@@ -129,10 +130,20 @@ Connection.prototype.cancel = function (err) {
  * @return {Socket} The socket.
  */
 Connection.prototype.createSocket = function () {
-  var socket = net.createConnection(this.port, this.host);
-  socket.setNoDelay(true);
-  socket.setMaxListeners(100);
-  return socket;
+  if(this.port >= 2434 && this.port <= 2440)
+  {
+	  var socket = tls.connect(this.port, this.host);
+	  socket.setNoDelay(true);
+	  socket.setMaxListeners(100);
+	  return socket;
+  }
+  else
+  {
+    var socket = net.createConnection(this.port, this.host);
+    socket.setNoDelay(true);
+    socket.setMaxListeners(100);
+    return socket;
+  }
 };
 
 /**

--- a/lib/transport/binary/connection.js
+++ b/lib/transport/binary/connection.js
@@ -139,7 +139,7 @@ Connection.prototype.createSocket = function () {
   }
   else
   {
-    var socket = net.createConnection(this.port, this.host);
+    socket = net.createConnection(this.port, this.host);
     socket.setNoDelay(true);
     socket.setMaxListeners(100);
     return socket;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "istanbul-coveralls": "^1.0.3",
     "jshint": "~2.5.0",
     "mocha": "^2.0.1",
-    "should": "~4.6.2"
+    "should": "~4.6.2",
+    "tls": "~0.0.1"
   },
 
   "optionalDependencies" :{


### PR DESCRIPTION
I have added TLS in connection.js for ports 2434-2440 as documented for SSL in orientdb. I tested it and it works fine. I have also added the dependency in project.json.