### PR TITLE
Upgrade request@2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bluebird": "~2.9.2",
     "fast.js": "^0.1.1",
     "parse-function": "^2.0.0",
-    "request": "~2.60.0",
+    "request": "~2.81.0",
     "node-biginteger": "^0.0.10",
     "yargs": "~1.2.1"
   },


### PR DESCRIPTION
Upgrading minimum `request` version from `2.60.0` to `2.81.0` due to High severity vulnerability found on `qs@4.0.0`
- desc: Prototype Override Protection Bypass
- info: https://snyk.io/vuln/npm:qs:20170213
- from:orientjs@2.2.4 > request@2.60.0 > qs@4.0.0

The latest version of request has a more recent version of `qs` (6.4.0) and the vulnerability has been fixed.