### PR TITLE
allow optional resolver in db.query and record.get

### DIFF
--- a/lib/db/db.js
+++ b/lib/db/db.js
@@ -318,6 +318,7 @@ Db.prototype.exec = function (query, options) {
  * @promise {Mixed}          The results of the query / command.
  */
 Db.prototype.query = function (command, options) {
+  options = options || {};
   return this.exec(command, options)
     .bind(this)
     .then(function (response) {

--- a/lib/db/db.js
+++ b/lib/db/db.js
@@ -360,7 +360,9 @@ Db.prototype.query = function (command, options) {
         }, [[], []]);
     })
     .spread(function (results, preloaded) {
-      results = this.record.resolveReferences(results, preloaded);
+      results =  options.resolver
+        ? options.resolver(results, preloaded)
+        : this.record.resolveReferences(results, preloaded);
       return results;
     });
 };
@@ -398,7 +400,9 @@ Db.prototype.liveQuery = function (command, options) {
         }, [[], []]);
     })
     .spread(function (results, preloaded) {
-      results = this.record.resolveReferences(results, preloaded);
+      results = options.resolver
+        ? options.resolver(results, preloaded)
+        : this.record.resolveReferences(results, preloaded);
       return results;
     })
     .then(function (response) {

--- a/lib/db/db.js
+++ b/lib/db/db.js
@@ -360,9 +360,9 @@ Db.prototype.query = function (command, options) {
         }, [[], []]);
     })
     .spread(function (results, preloaded) {
-      results =  options.resolver
-        ? options.resolver(results, preloaded)
-        : this.record.resolveReferences(results, preloaded);
+      results =  options.resolver ?
+        options.resolver(results, preloaded) :
+        this.record.resolveReferences(results, preloaded);
       return results;
     });
 };
@@ -400,9 +400,9 @@ Db.prototype.liveQuery = function (command, options) {
         }, [[], []]);
     })
     .spread(function (results, preloaded) {
-      results = options.resolver
-        ? options.resolver(results, preloaded)
-        : this.record.resolveReferences(results, preloaded);
+      results = options.resolver ?
+        options.resolver(results, preloaded) :
+        this.record.resolveReferences(results, preloaded);
       return results;
     })
     .then(function (response) {

--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -107,9 +107,9 @@ exports.get = function (record, options) {
         return response.records[0];
       }
       else {
-        response.records = options.resolver
-          ? options.resolver(response.records)
-          : this.record.resolveReferences(response.records);
+        response.records = options.resolver ?
+          options.resolver(response.records) :
+          this.record.resolveReferences(response.records);
         return response.records[0];
       }
     });

--- a/lib/db/record.js
+++ b/lib/db/record.js
@@ -107,7 +107,9 @@ exports.get = function (record, options) {
         return response.records[0];
       }
       else {
-        response.records = this.record.resolveReferences(response.records);
+        response.records = options.resolver
+          ? options.resolver(response.records)
+          : this.record.resolveReferences(response.records);
         return response.records[0];
       }
     });


### PR DESCRIPTION
Re: #254 #219 

Instead of messing with orientjs internals I think allowing an optional resolver in userspace is a nicer 'option'

