### PR TITLE
Add CONTENT statement for various methods such as UPDATE

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -134,6 +134,14 @@ Statement.prototype.to = clause('to');
 Statement.prototype.set = clause('set');
 
 /**
+ * Replace the record content with the given values.
+ *
+ * @param  {String|String[]} args The where clause
+ * @return {Statement}            The statement object.
+ */
+Statement.prototype.content = clause('content');
+
+/**
  * An `increment` clause.
  *
  * @param  {String}     property     The property name to put the key to.
@@ -708,6 +716,12 @@ Statement.prototype.buildStatement = function () {
       statement.push('SET');
       statement.push(values);
     }
+  }
+
+  if (state.content && state.content.length) {
+    var value = JSON.stringify(state.content[0]);
+    statement.push('CONTENT');
+    statement.push(value);
   }
 
   if (state.increment && state.increment.length) {

--- a/test/db/query-test.js
+++ b/test/db/query-test.js
@@ -351,6 +351,20 @@ describe("Database API - Query", function () {
         });
     });
   });
+  describe('Db::updateContent()', function () {
+    it('should update a user, replacing record content', function () {
+      var updatedUser = {
+        name: 'reader',
+        password: 'mynewerpassword',
+        status: 'active',
+        roles: ["#4:1"],
+        foo: 'bar'};
+      return this.db.update('OUser').content(updatedUser).where({name: 'reader'}).limit(1).scalar()
+        .then(function (count) {
+          count.should.eql('1');
+        });
+    });
+  });
   describe('Db::query()', function () {
     it('should execute an insert query', function () {
       return this.db.query('insert into OUser (name, password, status) values (:name, :password, :status)',

--- a/test/db/statement-test.js
+++ b/test/db/statement-test.js
@@ -225,6 +225,11 @@ COMMIT \n\
       this.statement.buildStatement().should.equal('UPDATE #1:1 SET foo = :paramfoo0, greeting = :paramgreeting1');
     });
 
+    it('should update a record, replacing all content', function () {
+      this.statement.update('#1:1').content({foo: 'bar', greeting: 'hello world'});
+      this.statement.buildStatement().should.equal('UPDATE #1:1 CONTENT {"foo":"bar","greeting":"hello world"}');
+    });
+
     it('should update a record with a nested statement', function () {
       this.statement.update('#1:1').set({
         foo: function (s) {


### PR DESCRIPTION
### Motivation / Problem:
Currently the query builder does not provide a way to replace the entire content of a record while preserving edges, `db.record.update()` (utilizing binary protocol REQUEST_RECORD_UPDATE) is only useful on documents, not vertices as it removes the vertex edges while leaving them in db (breaking graph consistency), `db.update.set()` does not replace the full content of a record, so in order to update one must first get the record and then update it, perhaps in a transaction. This is not ideal IMO.

### Solution:
This adds the CONTENT statement to allow one to update all record properties at once, while preserving existing edges.
