### PR TITLE
Remove duplication of RawExpression function in statement.js and fix …

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -14,7 +14,7 @@ function Statement(db) {
 // RawExpression Support
 function RawExpression(value, db) {
   this.value = value;
-  this.db = db;
+  this.db = value;
 }
 
 RawExpression.extend = utils.extend;

--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -14,14 +14,9 @@ function Statement(db) {
 // RawExpression Support
 function RawExpression(value, db) {
   this.value = value;
-  this.db = value;
+  this.db = db;
 }
 
-// RawExpression Support
-function RawExpression(value, db) {
-  this.value = value;
-  this.db = value;
-}
 RawExpression.extend = utils.extend;
 RawExpression.prototype.toString = function () {
   return this.value;


### PR DESCRIPTION
In **lib/statement.js** I found that the RawExpression was written twice. I also found that **this.db** was assigned with **value** parameter passed to it rather than the **db** parameter passed to the function.