### PR TITLE
Fixed some security issues, closes #324

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "yargs": "~1.2.1"
   },
   "devDependencies": {
-    "mocha": "^2.0.1",
+    "mocha": "^5.2.0",
     "should": "~4.6.2",
     "expect.js": "~0.3.1",
     "istanbul": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "should": "~4.6.2",
     "expect.js": "~0.3.1",
     "istanbul": "~0.2.7",
-    "istanbul-coveralls": "^1.0.3",
     "jshint": "~2.5.0",
     "tls": "~0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "mocha": "^2.0.1",
     "should": "~4.6.2",
     "expect.js": "~0.3.1",
-    "istanbul": "~0.2.7",
-    "jshint": "~2.5.0",
+    "istanbul": "~0.4.5",
+    "jshint": "~2.9.6",
     "tls": "~0.0.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bluebird": "~2.9.2",
     "fast.js": "^0.1.1",
     "parse-function": "^2.0.0",
-    "request": "~2.81.0",
+    "request": "~2.88.0",
     "node-biginteger": "^0.0.10",
     "yargs": "~1.2.1"
   },


### PR DESCRIPTION
Some of the dependencies are very old (version-wise) and have been updated.

I did run the tests, most of them were running successful. I'm no expert here, but 100% successful is not required for a successful merge, right? Right??

Anyway, I have removed `istanbul-coveralls` as it was not used anymore. `mocha` was updated from v2.x to v5.x and `request` was updated from v2.81 to v2.88. Running `npm audit` afterwards yielded no security issues anymore (yay!)