### PR TITLE
Update statement.js

### DIFF
--- a/lib/db/statement.js
+++ b/lib/db/statement.js
@@ -956,7 +956,7 @@ Statement.prototype.buildStatement = function () {
   }
 
   if (state.unwind && state.unwind.length) {
-    statement.push('UNWIND ' + statement.unwind.join(', '));
+    statement.push('UNWIND ' + state.unwind.join(', '));
   }
 
   if (state.limit) {


### PR DESCRIPTION
Fixing the unwind function, which was previously causing an error because it tried to use the unwind property of the 'statement' object rather than the 'state' object.