### PR TITLE
Fix parse-function to version 5.4.4, fixes #412

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "fast.js": "^0.1.1",
     "generic-pool": "^3.1.6",
     "node-biginteger": "^0.0.10",
-    "parse-function": "^5.2.9",
+    "parse-function": "5.4.4",
     "request": "^2.87.0",
     "signed-varint": "2.0.1",
     "tls": "~0.0.1",


### PR DESCRIPTION
Recent updates to parse-function have broken the library in general, and changed the interface a tiny bit, breaking orientjs. Fixing to the last known good version.

Fixes #412 